### PR TITLE
fix: aws-vault sets AWS_SECURITY_TOKEN, causing permission issues

### DIFF
--- a/upload.tf
+++ b/upload.tf
@@ -24,6 +24,7 @@ CREDENTIALS=(`aws sts assume-role \
 if [ $? -eq 0 ]
 then
   unset AWS_PROFILE
+  unset AWS_SECURITY_TOKEN
   export AWS_DEFAULT_REGION=${data.aws_region.current.name}
   export AWS_ACCESS_KEY_ID="$${CREDENTIALS[0]}"
   export AWS_SECRET_ACCESS_KEY="$${CREDENTIALS[1]}"


### PR DESCRIPTION
aws s3 cp gives a 403 Forbidden on HEAD operations